### PR TITLE
Add Meteor 0.9 support for the new meteor package manager

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,8 +1,11 @@
 Package.describe({
-  summary: 'A package that makes it easy to manage meta-data'
+  summary: 'A package that makes it easy to manage meta-data',
+  version: "0.1.2",
+  git: "https://github.com/yasinuslu/blaze-meta.git",
+  name: "yasinuslu:blaze-meta"
 });
 
-Package.on_use(function (api) {
+Package.onUse(function (api) {
   api.use("underscore", "client");
   api.use("deps", "client");
   api.use("session", "client");
@@ -13,6 +16,11 @@ Package.on_use(function (api) {
   api.add_files("lib/meta.js", "client");
 
   api.export("Meta");
+  
+  // check if is this Meteor 0.9 and add 0.9 related code
+  if(api.versionsFrom) {
+    api.versionsFrom('METEOR@0.9.0');
+  }
 });
 
 Package.on_test(function (api) {


### PR DESCRIPTION
I updated my meteor app to 0.9.1 and I was able to download mrt:blaze-meta from meteor (not from meteorite) but it is some cached old version of it because my patch (#3)  isn't there. If I do mrt add blaze-meta it's the last version. So check the link below and with the new package.json you can publish the new version of the package on meteor.
https://hackpad.com/Add-Meteor-0.9-support-for-your-Existing-Packages-P0R7y1PiXlu
