### PR TITLE
UI API is deprecated. Since Meteor 0.9.1 UI.insert and UI.render are merged into Blaze.render

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -90,7 +90,7 @@ Template.MetaTags.tags = function () {
 Meteor.startup(function () {
   Meta.init();
 
-  UI.insert(UI.render(Template.MetaTags), document.head);
+  Blaze.render(Template.MetaTags, document.head);
 
   Deps.autorun(function () {
     document.title = Meta.getTitle();


### PR DESCRIPTION
There are some API changes since 0.9.1. Some of them you can look [here](https://meteor.hackpad.com/Blaze-changes-for-0.9.1-XHBsah1DhX1). Meteor throws a warning message `W20140906-15:23:28.817(3) (blaze.js:67) Warning: Blaze.render without a parent element is deprecated. You must specify where to insert the rendered content.` because of these changes. I updated the package with the new Blaze API but that is a breaking change and maybe it's good idea to increment the version of the package. Also ui package and deps package will be removed from the dependencies (which is good :) ).
