### PR TITLE
Use current helpers API to avoid deprecation warnings.

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -81,19 +81,22 @@ Meta = {
   }
 }
 
-Template.MetaTags.tags = function() {
-  return Meta.arr();
-}
+Template.MetaTags.helpers({
 
-Template.MetaTags._MetaTag = function() {
-  var attrs = {};
-  attrs[this.name] = this.property;
-  attrs.content = this.content;
+  tags: function() {
+    return Meta.arr();
+  },
 
-  return Blaze.Template(function() {
-    return HTML.META(attrs);
-  });
-};
+  _MetaTag: function() {
+    var attrs = {};
+    attrs[this.name] = this.property;
+    attrs.content = this.content;
+
+    return Blaze.Template(function() {
+      return HTML.META(attrs);
+    });
+  }
+});
 
 Meteor.startup(function() {
   Meta.init();

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Blaze-meta makes it super simple to manage SEO data.',
-  version: "0.2.1",
+  version: "0.2.2",
   git: "https://github.com/yasinuslu/blaze-meta.git",
   name: "yasinuslu:blaze-meta"
 });

--- a/versions.json
+++ b/versions.json
@@ -2,90 +2,90 @@
   "dependencies": [
     [
       "base64",
-      "1.0.0"
-    ],
-    [
-      "blaze",
-      "2.0.1"
-    ],
-    [
-      "deps",
-      "1.0.4"
-    ],
-    [
-      "ejson",
-      "1.0.3"
-    ],
-    [
-      "geojson-utils",
-      "1.0.0"
-    ],
-    [
-      "htmljs",
       "1.0.1"
     ],
     [
+      "blaze",
+      "2.0.2"
+    ],
+    [
+      "deps",
+      "1.0.5"
+    ],
+    [
+      "ejson",
+      "1.0.4"
+    ],
+    [
+      "geojson-utils",
+      "1.0.1"
+    ],
+    [
+      "htmljs",
+      "1.0.2"
+    ],
+    [
       "id-map",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "jquery",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "json",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "meteor",
-      "1.1.1"
+      "1.1.2"
     ],
     [
       "minimongo",
-      "1.0.3"
+      "1.0.4"
     ],
     [
       "observe-sequence",
-      "1.0.2"
+      "1.0.3"
     ],
     [
       "ordered-dict",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "random",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "reactive-dict",
-      "1.0.3"
+      "1.0.4"
     ],
     [
       "reactive-var",
-      "1.0.2"
-    ],
-    [
-      "session",
-      "1.0.2"
-    ],
-    [
-      "templating",
-      "1.0.7"
-    ],
-    [
-      "tracker",
-      "1.0.2"
-    ],
-    [
-      "ui",
       "1.0.3"
     ],
     [
+      "session",
+      "1.0.3"
+    ],
+    [
+      "templating",
+      "1.0.8"
+    ],
+    [
+      "tracker",
+      "1.0.3"
+    ],
+    [
+      "ui",
+      "1.0.4"
+    ],
+    [
       "underscore",
-      "1.0.0"
+      "1.0.1"
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.33",
+  "toolVersion": "meteor-tool@1.0.34",
   "format": "1.0"
 }


### PR DESCRIPTION
I got annoyed from the deprecation warnings so I updated the helpers to be defined in the current way. So, now we get no more deprecation warnings which is nice.
