### PR TITLE
allow to unset tags added using the alternate syntax

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -59,7 +59,8 @@ Meta = {
 
   unset: function(property) {
     var meta = Meta.getVar("tag") || {};
-    delete meta[property];
+    var m = Meta.converters.meta(property);
+    delete meta[m.property];
     Meta.setVar("tag", meta);
   },
 


### PR DESCRIPTION
Make it possible something like this.

``` js
Meta.unset({
  name: 'name',
  property: 'description'
});
```
